### PR TITLE
remove the default mandatory auto key field.

### DIFF
--- a/engines/csvengine.py
+++ b/engines/csvengine.py
@@ -56,7 +56,7 @@ class engine(Engine):
         self.auto_column_number = 1
         self.output_file = open(self.table_name(), "w")
         self.output_file.write(
-            ','.join(['"%s"' % c[0] for c in self.table.columns]))
+            ','.join(['"%s"' % c for c in self.table.get_insert_columns(join=False,create=True)]))
 
     def disconnect(self):
         """Close the last file in the dataset"""
@@ -74,7 +74,7 @@ class engine(Engine):
 
     def format_insert_value(self, value, datatype):
         """Formats a value for an insert statement"""
-        v = Engine.format_insert_value(self, value, datatype)
+        v = Engine.format_insert_value(self, value, datatype, escape=False)
         if v == 'null':
             return ""
         try:
@@ -86,17 +86,14 @@ class engine(Engine):
 
     def insert_statement(self, values):
         """Returns a comma delimited row of values"""
+
         if not hasattr(self, 'auto_column_number'):
             self.auto_column_number = 1
-        offset = 0
-        for i in range(len(self.table.columns)):
-            column = self.table.columns[i]
-            if 'auto' in column[1][0]:
-                values = values[:i + offset] + \
-                    [self.auto_column_number] + values[i + offset:]
-                self.auto_column_number += 1
-                offset += 1
-        return ','.join([str(value) for value in values])
+        insert_stmt = ','.join([str(value) for value in values])
+        if self.table.columns[0][1][0][3:] == 'auto':
+            insert_stmt = str(self.auto_column_number) + "," + insert_stmt
+            self.auto_column_number += 1
+        return insert_stmt
 
     def table_exists(self, dbname, tablename):
         """Check to see if the data file currently exists"""

--- a/engines/jsonengine.py
+++ b/engines/jsonengine.py
@@ -91,7 +91,7 @@ class engine(Engine):
 
     def format_insert_value(self, value, datatype):
         """Formats a value for an insert statement"""
-        v = Engine.format_insert_value(self, value, datatype)
+        v = Engine.format_insert_value(self, value, datatype, escape=False)
         if v == 'null':
             return ""
         try:
@@ -104,16 +104,12 @@ class engine(Engine):
     def insert_statement(self, values):
         if not hasattr(self, 'auto_column_number'):
             self.auto_column_number = 1
-        offset = 0
-        for i in range(len(self.table.columns)):
-            column = self.table.columns[i]
-            if 'auto' in column[1][0]:
-                values = values[:i + offset] + \
-                         [self.auto_column_number] + values[i + offset:]
-                self.auto_column_number += 1
-                offset += 1
 
-        keys = [columnname[0] for columnname in self.table.columns]
+        if self.table.columns[0][1][0][3:] == 'auto':
+            values = [str(self.auto_column_number)] + values
+            self.auto_column_number += 1
+
+        keys = self.table.get_insert_columns(join=False, create=True)
         tuples = (zip(keys, values))
         write_data = OrderedDict(tuples)
         return json.dumps(write_data, ensure_ascii=False)

--- a/engines/xmlengine.py
+++ b/engines/xmlengine.py
@@ -91,7 +91,7 @@ class engine(Engine):
     def format_insert_value(self, value, datatype):
 
         """Formats a value for an insert statement"""
-        v = Engine.format_insert_value(self, value, datatype)
+        v = Engine.format_insert_value(self, value, datatype, escape=False)
         if v == 'null':
             return ""
         try:
@@ -104,15 +104,13 @@ class engine(Engine):
     def insert_statement(self, values):
         if not hasattr(self, 'auto_column_number'):
             self.auto_column_number = 1
-        offset = 0
-        for i in range(len(self.table.columns)):
-            column = self.table.columns[i]
-            if 'auto' in column[1][0]:
-                values = values[:i + offset] + [self.auto_column_number] + values[i + offset:]
-                self.auto_column_number += 1
-                offset += 1
+
+        if self.table.columns[0][1][0][3:] == 'auto':
+            values = [str(self.auto_column_number)] + values
+            self.auto_column_number += 1
+
         open_tag = '<row>\n'
-        keys = [columnname[0] for columnname in self.table.columns]
+        keys = self.table.get_insert_columns(join=False, create=True)
         write_data = ""
         for i in range(len(keys)):
             write_data += '    ' + '<' + str(keys[i]) + '>' + str(values[i]) + '</' + str(keys[i]) + '>' + "\n"

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -12,7 +12,7 @@ from retriever.lib.tools import file_2string
 simple_csv = {'name': 'simple_csv',
               'raw_data': "a,b,c\n1,2,3\n4,5,6\n",
               'script': "shortname: simple_csv\ntable: simple_csv, http://example.com/simple_csv.txt",
-              'expect_out': '"record_id","a","b","c"\n1,1,2,3\n2,4,5,6'}
+              'expect_out': '"a","b","c"\n1,2,3\n4,5,6'}
 
 crosstab = {'name': 'crosstab',
             'raw_data': "a,b,c1,c2\n1,1,1.1,1.2\n1,2,2.1,2.2",

--- a/test/test_regression_cli.py
+++ b/test/test_regression_cli.py
@@ -22,13 +22,7 @@ download_md5 = [
 
 db_md5 = [
     # ('DelMoral2010', '0'),
-    ('EA_avianbodysize2007', '74a5421622ab73c1df2ff8afc9d67e03'),
-    ('EA_mom2003', '92bf63eb5b36b777c600d0a95229222c')
-]
-
-filedb_md5 = [
-    # ('DelMoral2010', '0'),
-    ('EA_avianbodysize2007', 'ca8f7e670ff98b520371d3fabf9a8632'),
+    ('EA_avianbodysize2007', '79680888f7768474479e70c87cd36c9d'),
     ('EA_mom2003', '92bf63eb5b36b777c600d0a95229222c')
 ]
 
@@ -91,21 +85,21 @@ def test_mysql_regression(dataset, expected, tmpdir):
     assert get_csv_md5(dataset, mysql_engine, tmpdir) == expected
 
 
-@pytest.mark.parametrize("dataset, expected", filedb_md5)
+@pytest.mark.parametrize("dataset, expected", db_md5)
 def test_xmlenginee_regression(dataset, expected, tmpdir):
     """Check for xmlenginee regression"""
     xml_engine.opts = {'engine': 'xml', 'table_name': 'output_file_{table}.xml'}
     assert get_csv_md5(dataset, xml_engine, tmpdir) == expected
 
 
-@pytest.mark.parametrize("dataset, expected", filedb_md5)
+@pytest.mark.parametrize("dataset, expected", db_md5)
 def test_jsonenginee_regression(dataset, expected, tmpdir):
     """Check for jsonenginee regression"""
     json_engine.opts = {'engine': 'json', 'table_name': 'output_file_{table}.json'}
     assert get_csv_md5(dataset, json_engine, tmpdir) == expected
 
 
-@pytest.mark.parametrize("dataset, expected", filedb_md5)
+@pytest.mark.parametrize("dataset, expected", db_md5)
 def test_csv_regression(dataset, expected, tmpdir):
     """Check csv regression"""
     csv_engine.opts = {'engine': 'csv', 'table_name': 'output_file_{table}.csv'}


### PR DESCRIPTION
currently all the file based engines create an auto increment field
if the table columns are not defined.

When fields are not defined, the auto pk is None and the previous
version was by default setting auto field as the first colum value.

This check as been removed and put in auto_get_datatypes and will be part of
adding the capability of only defining the primary key in the scripts
ref:#188
