### PR TITLE
Refactoring __init__.py to avoid cyclic dependency

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,9 +9,9 @@ if hasattr(sys, 'setdefaultencoding'):
     sys.setdefaultencoding('latin-1')
 
 from builtins import str
-from retriever import VERSION,COPYRIGHT
+from retriever.lib.defaults import VERSION, COPYRIGHT
 from retriever.lib.repository import check_for_updates
-from retriever import SCRIPT_LIST
+from retriever.lib.scripts import SCRIPT_LIST
 
 # Create the .rst file for the available datasets
 datasetfile = open("datasets.rst", "w")

--- a/docs/retriever.lib.rst
+++ b/docs/retriever.lib.rst
@@ -68,6 +68,14 @@ retriever.lib.repository module
     :undoc-members:
     :show-inheritance:
 
+retriever.lib.scripts module
+----------------------------
+
+.. automodule:: retriever.lib.scripts
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 retriever.lib.table module
 --------------------------
 

--- a/retriever/__init__.py
+++ b/retriever/__init__.py
@@ -12,28 +12,16 @@ import io
 import os
 import sys
 import csv
-from os.path import join, isfile, getmtime, exists
-from pkg_resources import parse_version
-import imp
 import platform
 
-from retriever.lib.compile import compile_json
-from retriever._version import __version__
+from retriever.lib.defaults import HOME_DIR, ENCODING
 
 current_platform = platform.system().lower()
 if current_platform != 'windows':
     import pwd
 
-VERSION = __version__
-COPYRIGHT = "Copyright (C) 2011-2016 Weecology University of Florida"
-REPO_URL = "https://raw.github.com/weecology/retriever/"
-MASTER_BRANCH = REPO_URL + "master/"
-REPOSITORY = MASTER_BRANCH
-ENCODING = 'ISO-8859-1'
-
 # create the necessary directory structure for storing scripts/raw_data
 # in the ~/.retriever directory
-HOME_DIR = os.path.expanduser('~/.retriever/')
 for dir in (HOME_DIR, os.path.join(HOME_DIR, 'raw_data'), os.path.join(HOME_DIR, 'scripts')):
     if not os.path.exists(dir):
         try:
@@ -46,25 +34,9 @@ for dir in (HOME_DIR, os.path.join(HOME_DIR, 'raw_data'), os.path.join(HOME_DIR,
         except OSError:
             print("The Retriever lacks permission to access the ~/.retriever/ directory.")
             raise
-SCRIPT_SEARCH_PATHS = [
-    "./",
-    'scripts',
-    os.path.join(HOME_DIR, 'scripts/')
-]
-SCRIPT_WRITE_PATH = SCRIPT_SEARCH_PATHS[-1]
-DATA_SEARCH_PATHS = [
-    "./",
-    "{dataset}",
-    "raw_data/{dataset}",
-    os.path.join(HOME_DIR, 'raw_data/{dataset}'),
-]
-DATA_WRITE_PATH = DATA_SEARCH_PATHS[-1]
-
-# Create default data directory
-DATA_DIR = '.'
 
 
-def open_fr(file_name, encoding=ENCODING, encode=True):
+def open_fr(file_name, encoding='ISO-8859-1', encode=True):
     """Open file for reading respecting Python version and OS differences
 
     Sets newline to Linux line endings on Windows and Python 3
@@ -118,62 +90,6 @@ def to_str(object, object_encoding=sys.stdout):
         return str(object).encode(enc, errors='backslashreplace').decode("latin-1")
     else:
         return object
-
-
-def MODULE_LIST(force_compile=False):
-    """Load scripts from scripts directory and return list of modules."""
-    modules = []
-    loaded_scripts = []
-
-    for search_path in [search_path for search_path in SCRIPT_SEARCH_PATHS if exists(search_path)]:
-        to_compile = [
-            file for file in os.listdir(search_path) if file[-5:] == ".json" and
-            file[0] != "_" and (
-                (not isfile(join(search_path, file[:-5] + '.py'))) or (
-                    isfile(join(search_path, file[:-5] + '.py')) and (
-                        getmtime(join(search_path, file[:-5] + '.py')) < getmtime(
-                            join(search_path, file)))) or force_compile)]
-        for script in to_compile:
-            script_name = '.'.join(script.split('.')[:-1])
-            compile_json(join(search_path, script_name))
-
-        files = [file for file in os.listdir(search_path)
-                 if file[-3:] == ".py" and file[0] != "_" and
-                 '#retriever' in ' '.join(open(join(search_path, file), 'r').readlines()[:2]).lower()]
-
-        for script in files:
-            script_name = '.'.join(script.split('.')[:-1])
-            if script_name not in loaded_scripts:
-                loaded_scripts.append(script_name)
-                file, pathname, desc = imp.find_module(script_name, [search_path])
-                try:
-                    new_module = imp.load_module(script_name, file, pathname, desc)
-                    if hasattr(new_module.SCRIPT, "retriever_minimum_version"):
-                        # a script with retriever_minimum_version should be loaded
-                        # only if its compliant with the version of the retriever
-                        if not parse_version(VERSION) >=  parse_version("{}".format(
-                                new_module.SCRIPT.retriever_minimum_version)):
-                            print("{} is supported by Retriever version {}".format(script_name,
-                                                                                   new_module.SCRIPT.retriever_minimum_version))
-                            print("Current version is {}".format(VERSION))
-                            continue
-                    # if the script wasn't found in an early search path
-                    # make sure it works and then add it
-                    new_module.SCRIPT.download
-                    modules.append(new_module)
-                except Exception as e:
-                    sys.stderr.write("Failed to load script: %s (%s)\nException: %s \n" % (
-                        script_name, search_path, str(e)))
-    return modules
-
-
-def SCRIPT_LIST(force_compile=False):
-    return [module.SCRIPT for module in MODULE_LIST(force_compile)]
-
-
-def ENGINE_LIST():
-    from retriever.engines import engine_list
-    return engine_list
 
 
 def set_proxy():

--- a/retriever/__main__.py
+++ b/retriever/__main__.py
@@ -22,10 +22,12 @@ reload(sys)
 if hasattr(sys, 'setdefaultencoding'):
     sys.setdefaultencoding(encoding)
 
-from retriever import VERSION, SCRIPT_LIST, HOME_DIR, sample_script, CITATION
-from retriever.engines import engine_list
+from retriever import sample_script, CITATION
+from retriever.lib.defaults import VERSION, HOME_DIR
+from retriever.lib.scripts import SCRIPT_LIST
+from retriever.engines import engine_list, choose_engine
 from retriever.lib.repository import check_for_updates
-from retriever.lib.tools import choose_engine, name_matches, reset_retriever
+from retriever.lib.tools import name_matches, reset_retriever
 from retriever.lib.get_opts import parser
 from retriever.lib.datapackage import create_json, edit_json
 

--- a/retriever/compile.py
+++ b/retriever/compile.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
-from retriever import MODULE_LIST
+from retriever.lib.scripts import MODULE_LIST
 
 
 def compile():

--- a/retriever/engines/__init__.py
+++ b/retriever/engines/__init__.py
@@ -1,4 +1,5 @@
 """Contains DBMS-specific Engine implementations."""
+from retriever.lib.engine import Engine
 
 engines = [
     "mysql",
@@ -17,3 +18,37 @@ engine_module_list = [
 ]
 
 engine_list = [module.engine() for module in engine_module_list]
+
+
+def choose_engine(opts, choice=True):
+    """Prompts the user to select a database engine"""
+
+    if "engine" in list(opts.keys()):
+        enginename = opts["engine"]
+    elif opts["command"] == "download":
+        enginename = "download"
+    else:
+        if not choice:
+            return None
+        print("Choose a database engine:")
+        for engine in engine_list:
+            if engine.abbreviation:
+                abbreviation = "(" + engine.abbreviation + ") "
+            else:
+                abbreviation = ""
+            print("    " + abbreviation + engine.name)
+        enginename = input(": ")
+    enginename = enginename.lower()
+
+    engine = Engine()
+    if not enginename:
+        engine = engine_list[0]
+    else:
+        for thisengine in engine_list:
+            if (enginename == thisengine.name.lower() or
+                    thisengine.abbreviation and
+                    enginename == thisengine.abbreviation):
+                engine = thisengine
+
+    engine.opts = opts
+    return engine

--- a/retriever/engines/csvengine.py
+++ b/retriever/engines/csvengine.py
@@ -7,7 +7,8 @@ import sys
 import csv
 
 from retriever.lib.models import Engine
-from retriever import DATA_DIR, open_fw, open_csvw
+from retriever import open_fw, open_csvw
+from retriever.lib.defaults import DATA_DIR
 from retriever.lib.tools import sort_csv
 
 

--- a/retriever/engines/download_only.py
+++ b/retriever/engines/download_only.py
@@ -7,7 +7,7 @@ import inspect
 
 from retriever.lib.engine import filename_from_url
 from retriever.lib.models import Engine, no_cleanup
-from retriever import DATA_DIR, HOME_DIR
+from retriever.lib.defaults import DATA_DIR, HOME_DIR
 
 
 class DummyConnection(object):

--- a/retriever/engines/jsonengine.py
+++ b/retriever/engines/jsonengine.py
@@ -7,7 +7,8 @@ import os
 import json
 
 from retriever.lib.models import Engine
-from retriever import DATA_DIR, open_fw, open_fr
+from retriever import open_fw, open_fr
+from retriever.lib.defaults import DATA_DIR
 from collections import OrderedDict
 from retriever.lib.tools import json2csv, sort_csv
 

--- a/retriever/engines/msaccess.py
+++ b/retriever/engines/msaccess.py
@@ -2,7 +2,8 @@ from __future__ import print_function
 from builtins import str
 import os
 from retriever.lib.models import Engine, no_cleanup
-from retriever import DATA_DIR, current_platform
+from retriever import current_platform
+from retriever.lib.defaults import DATA_DIR
 
 
 class engine(Engine):

--- a/retriever/engines/sqlite.py
+++ b/retriever/engines/sqlite.py
@@ -1,7 +1,7 @@
 from builtins import range
 import os
 from retriever.lib.models import Engine, no_cleanup
-from retriever import DATA_DIR
+from retriever.lib.defaults import DATA_DIR
 
 
 class engine(Engine):

--- a/retriever/engines/xmlengine.py
+++ b/retriever/engines/xmlengine.py
@@ -4,7 +4,8 @@ from builtins import str
 from builtins import object
 from builtins import range
 from retriever.lib.models import Engine
-from retriever import DATA_DIR, open_fr, open_fw
+from retriever import open_fr, open_fw
+from retriever.lib.defaults import DATA_DIR
 from retriever.lib.tools import xml2csv, sort_csv
 
 

--- a/retriever/lib/datapackage.py
+++ b/retriever/lib/datapackage.py
@@ -3,7 +3,8 @@ from builtins import input
 import os
 import json
 from time import sleep
-from retriever import SCRIPT_LIST, HOME_DIR, ENCODING
+from retriever.lib.scripts import SCRIPT_LIST
+from retriever.lib.defaults import HOME_DIR, ENCODING
 
 short_names = [script.shortname.lower() for script in SCRIPT_LIST()]
 

--- a/retriever/lib/defaults.py
+++ b/retriever/lib/defaults.py
@@ -1,0 +1,27 @@
+import os
+from retriever._version import __version__
+
+VERSION = __version__
+COPYRIGHT = "Copyright (C) 2011-2016 Weecology University of Florida"
+REPO_URL = "https://raw.github.com/weecology/retriever/"
+MASTER_BRANCH = REPO_URL + "master/"
+REPOSITORY = MASTER_BRANCH
+ENCODING = 'ISO-8859-1'
+
+HOME_DIR = os.path.expanduser('~/.retriever/')
+SCRIPT_SEARCH_PATHS = [
+    "./",
+    'scripts',
+    os.path.join(HOME_DIR, 'scripts/')
+]
+SCRIPT_WRITE_PATH = SCRIPT_SEARCH_PATHS[-1]
+DATA_SEARCH_PATHS = [
+    "./",
+    "{dataset}",
+    "raw_data/{dataset}",
+    os.path.join(HOME_DIR, 'raw_data/{dataset}'),
+]
+DATA_WRITE_PATH = DATA_SEARCH_PATHS[-1]
+
+# Create default data directory
+DATA_DIR = '.'

--- a/retriever/lib/engine.py
+++ b/retriever/lib/engine.py
@@ -19,7 +19,8 @@ import re
 import io
 import time
 from urllib.request import urlretrieve
-from retriever import DATA_SEARCH_PATHS, DATA_WRITE_PATH, open_fr, open_fw, open_csvw
+from retriever import open_fr, open_fw, open_csvw
+from retriever.lib.defaults import DATA_SEARCH_PATHS, DATA_WRITE_PATH
 from retriever.lib.cleanup import no_cleanup
 from retriever.lib.warning import Warning
 

--- a/retriever/lib/get_opts.py
+++ b/retriever/lib/get_opts.py
@@ -1,12 +1,12 @@
 import argparse
 import os
-from retriever import VERSION
+from retriever.lib.defaults import VERSION
+from retriever.lib.scripts import MODULE_LIST
 from retriever.engines import engine_list
 import argcomplete
 
 from argcomplete.completers import ChoicesCompleter
 
-from retriever import MODULE_LIST
 
 module_list = MODULE_LIST()
 script_list = [module.SCRIPT.shortname for module in module_list]

--- a/retriever/lib/repository.py
+++ b/retriever/lib/repository.py
@@ -9,7 +9,7 @@ import urllib.parse
 import urllib.error
 import imp
 from pkg_resources import parse_version
-from retriever import REPOSITORY, SCRIPT_WRITE_PATH, HOME_DIR
+from retriever.lib.defaults import REPOSITORY, SCRIPT_WRITE_PATH, HOME_DIR
 from retriever.lib.models import file_exists
 
 global abort, executable_name

--- a/retriever/lib/scripts.py
+++ b/retriever/lib/scripts.py
@@ -1,0 +1,60 @@
+
+import os
+from os.path import join, isfile, getmtime, exists
+from pkg_resources import parse_version
+import imp
+import sys
+
+from retriever.lib.defaults import SCRIPT_SEARCH_PATHS, VERSION
+from retriever.lib.compile import compile_json
+
+
+def MODULE_LIST(force_compile=False):
+    """Load scripts from scripts directory and return list of modules."""
+    modules = []
+    loaded_scripts = []
+
+    for search_path in [search_path for search_path in SCRIPT_SEARCH_PATHS if exists(search_path)]:
+        to_compile = [
+            file for file in os.listdir(search_path) if file[-5:] == ".json" and
+            file[0] != "_" and (
+                (not isfile(join(search_path, file[:-5] + '.py'))) or (
+                    isfile(join(search_path, file[:-5] + '.py')) and (
+                        getmtime(join(search_path, file[:-5] + '.py')) < getmtime(
+                            join(search_path, file)))) or force_compile)]
+        for script in to_compile:
+            script_name = '.'.join(script.split('.')[:-1])
+            compile_json(join(search_path, script_name))
+
+        files = [file for file in os.listdir(search_path)
+                 if file[-3:] == ".py" and file[0] != "_" and
+                 '#retriever' in ' '.join(open(join(search_path, file), 'r').readlines()[:2]).lower()]
+
+        for script in files:
+            script_name = '.'.join(script.split('.')[:-1])
+            if script_name not in loaded_scripts:
+                loaded_scripts.append(script_name)
+                file, pathname, desc = imp.find_module(script_name, [search_path])
+                try:
+                    new_module = imp.load_module(script_name, file, pathname, desc)
+                    if hasattr(new_module.SCRIPT, "retriever_minimum_version"):
+                        # a script with retriever_minimum_version should be loaded
+                        # only if its compliant with the version of the retriever
+                        if not parse_version(VERSION) >=  parse_version("{}".format(
+                                new_module.SCRIPT.retriever_minimum_version)):
+                            print("{} is supported by Retriever version {}".format(script_name,
+                                                                                   new_module.SCRIPT.retriever_minimum_version))
+                            print("Current version is {}".format(VERSION))
+                            continue
+                    # if the script wasn't found in an early search path
+                    # make sure it works and then add it
+                    new_module.SCRIPT.download
+                    modules.append(new_module)
+                except Exception as e:
+                    sys.stderr.write("Failed to load script: %s (%s)\nException: %s \n" % (
+                        script_name, search_path, str(e)))
+    return modules
+
+
+def SCRIPT_LIST(force_compile=False):
+    return [module.SCRIPT for module in MODULE_LIST(force_compile)]

--- a/retriever/lib/templates.py
+++ b/retriever/lib/templates.py
@@ -4,9 +4,9 @@ from __future__ import print_function
 from builtins import object
 import os
 import shutil
-from retriever import DATA_DIR
+from retriever.lib.defaults import DATA_DIR
 from retriever.lib.models import *
-from retriever.lib.tools import choose_engine
+from retriever.engines import choose_engine
 
 
 class Script(object):

--- a/retriever/lib/tools.py
+++ b/retriever/lib/tools.py
@@ -21,7 +21,8 @@ import shutil
 from decimal import Decimal
 from hashlib import md5
 
-from retriever import HOME_DIR, open_fr, open_fw, open_csvw
+from retriever import open_fr, open_fw, open_csvw
+from retriever.lib.defaults import HOME_DIR
 from retriever.lib.models import *
 import csv
 import json
@@ -100,42 +101,6 @@ def get_default_connection():
         return default_connection
     else:
         return None
-
-
-def choose_engine(opts, choice=True):
-    """Prompts the user to select a database engine"""
-    from retriever.engines import engine_list
-
-    if "engine" in list(opts.keys()):
-        enginename = opts["engine"]
-    elif opts["command"] == "download":
-        enginename = "download"
-    else:
-        if not choice:
-            return None
-        print("Choose a database engine:")
-        for engine in engine_list:
-            if engine.abbreviation:
-                abbreviation = "(" + engine.abbreviation + ") "
-            else:
-                abbreviation = ""
-            print("    " + abbreviation + engine.name)
-        enginename = input(": ")
-    enginename = enginename.lower()
-
-    engine = Engine()
-    if not enginename:
-        engine = engine_list[0]
-    else:
-        for thisengine in engine_list:
-            if (enginename == thisengine.name.lower() or
-                    thisengine.abbreviation and
-                    enginename == thisengine.abbreviation):
-                engine = thisengine
-
-    engine.opts = opts
-    return engine
-
 
 def reset_retriever(scope):
     """Remove stored information on scripts, data, and connections"""

--- a/retriever/try_install_all.py
+++ b/retriever/try_install_all.py
@@ -2,7 +2,7 @@
 
 This module, when run, attempts to install datasets from all Retriever scripts
 in the /scripts folder (except for those listed in IGNORE), for each engine in
-ENGINE_LIST() from __init__.py. In other words, it runs trys to install using
+engine_list in retriever.engines. In other words, it runs trys to install using
 all possible combinations of database platform and script and checks to
 see if there are any errors. It does not check the values in the database.
 
@@ -12,8 +12,8 @@ from __future__ import absolute_import
 import os
 import sys
 from imp import reload
-from retriever.lib.tools import choose_engine
-from retriever import MODULE_LIST, ENGINE_LIST, SCRIPT_LIST
+from retriever.lib.scripts import MODULE_LIST, SCRIPT_LIST
+from retriever.engines import engine_list, choose_engine
 
 reload(sys)
 if hasattr(sys, 'setdefaultencoding'):
@@ -24,7 +24,7 @@ else:
     os_password = ""
 
 MODULE_LIST = MODULE_LIST()
-ENGINE_LIST = ENGINE_LIST()
+ENGINE_LIST = engine_list
 if len(sys.argv) > 1:
     ENGINE_LIST = [
                     e for e in ENGINE_LIST

--- a/scripts/MammalSuperTree.py
+++ b/scripts/MammalSuperTree.py
@@ -1,5 +1,5 @@
 #retriever
-from retriever import VERSION
+from retriever.lib.defaults import VERSION
 from retriever.lib.templates import DownloadOnlyTemplate
 
 SCRIPT = DownloadOnlyTemplate(name="Mammal Super Tree",

--- a/scripts/breed_bird_survey.py
+++ b/scripts/breed_bird_survey.py
@@ -14,8 +14,8 @@ import zipfile
 from decimal import Decimal
 from retriever.lib.templates import Script
 from retriever.lib.models import Table, Cleanup, no_cleanup, correct_invalid_value
-from retriever import HOME_DIR, open_fr, open_fw
-
+from retriever import open_fr, open_fw
+from retriever.lib.defaults import HOME_DIR
 
 class main(Script):
     def __init__(self, **kwargs):

--- a/scripts/breed_bird_survey_50stop.py
+++ b/scripts/breed_bird_survey_50stop.py
@@ -15,7 +15,8 @@ import zipfile
 from decimal import Decimal
 from retriever.lib.templates import Script
 from retriever.lib.models import Table, Cleanup, no_cleanup, correct_invalid_value
-from retriever import HOME_DIR, open_fr, open_fw
+from retriever import open_fr, open_fw
+from retriever.lib.defaults import HOME_DIR
 
 
 class main(Script):

--- a/scripts/plant_life_hist_eu.py
+++ b/scripts/plant_life_hist_eu.py
@@ -3,7 +3,8 @@
 from builtins import str
 from retriever.lib.models import Table, Cleanup, correct_invalid_value
 from retriever.lib.templates import Script
-from retriever import HOME_DIR, open_fr, open_fw
+from retriever import open_fr, open_fw
+from retriever.lib.defaults import HOME_DIR
 
 
 class main(Script):

--- a/scripts/wood_density.py
+++ b/scripts/wood_density.py
@@ -12,7 +12,8 @@ from imp import reload
 from retriever.lib.templates import Script
 from retriever.lib.models import Table
 from retriever.lib.excel import Excel
-from retriever import HOME_DIR, open_fr, open_fw, open_csvw, to_str
+from retriever import open_fr, open_fw, open_csvw, to_str
+from retriever.lib.defaults import HOME_DIR
 
 class main(Script):
     def __init__(self, **kwargs):

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -15,7 +15,8 @@ if hasattr(sys, 'setdefaultencoding'):
     sys.setdefaultencoding(encoding)
 import pytest
 from retriever.lib.compile import compile_json
-from retriever import HOME_DIR, ENGINE_LIST
+from retriever.lib.defaults import HOME_DIR
+from retriever.engines import engine_list
 from retriever.lib.tools import file_2string
 from retriever.lib.tools import create_file
 
@@ -412,7 +413,7 @@ def get_script_module(script_name):
     return imp.load_module(script_name, file, pathname, desc)
 
 
-mysql_engine, postgres_engine, sqlite_engine, msaccess_engine, csv_engine, download_engine, json_engine, xml_engine = ENGINE_LIST()
+mysql_engine, postgres_engine, sqlite_engine, msaccess_engine, csv_engine, download_engine, json_engine, xml_engine = engine_list
 
 
 @pytest.mark.parametrize("dataset, expected", test_parameters)

--- a/test/test_regression_cli.py
+++ b/test/test_regression_cli.py
@@ -13,7 +13,7 @@ if hasattr(sys, 'setdefaultencoding'):
     sys.setdefaultencoding(encoding)
 import pytest
 from retriever.lib.tools import getmd5
-from retriever import ENGINE_LIST
+from retriever.engines import engine_list
 
 # Set postgres password, Appveyor service needs the password given
 # The Travis service obtains the password from the config file.
@@ -22,7 +22,7 @@ if os.name == "nt":
 else:
     os_password = ""
 
-mysql_engine, postgres_engine, sqlite_engine, msaccess_engine, csv_engine, download_engine, json_engine, xml_engine = ENGINE_LIST()
+mysql_engine, postgres_engine, sqlite_engine, msaccess_engine, csv_engine, download_engine, json_engine, xml_engine = engine_list
 file_location = os.path.dirname(os.path.realpath(__file__))
 retriever_root_dir = os.path.abspath(os.path.join(file_location, os.pardir))
 working_script_dir = os.path.abspath(os.path.join(retriever_root_dir, "scripts"))

--- a/version.py
+++ b/version.py
@@ -1,7 +1,8 @@
 """Generates a configuration file containing the version number."""
 from __future__ import absolute_import
 import os
-from retriever import VERSION, MODULE_LIST
+from retriever.lib.defaults import VERSION
+from retriever.lib.scripts import MODULE_LIST
 
 
 def get_module_version():


### PR DESCRIPTION
File __init__.py contains the widely used functions MODULE_LIST and
SCRIPT_LIST. However, since this file is imported in all over the
project, it causes cyclic dependency very often. E.g. in order to import
lib/templates.py in lib/compile.json, a cycle is encountered -
lib/compile.py -> lib/templates.py -> __init__.py -> lib/compile.py.
These two functions have been refactored into a new script located at
lib/scripts.py.

The constant components of __init__.py such as HOME_DIR etc. are also
referenced much often. These variables have also been refactored into
lib/defaults.py.

The references to these variables and functions have been modified
throughout the project to keep it consistent. THe documentation has been
modified as well to accomodate the newly generated lib/scripts.py
module.